### PR TITLE
Fixed translate issue

### DIFF
--- a/src/bin/network_tools_app/dict_translate.py
+++ b/src/bin/network_tools_app/dict_translate.py
@@ -117,7 +117,7 @@ def translate_key(existing_key, re_rules):
         if re.match(rule[0], existing_key):
             return rule[1]
 
-    return None
+    return existing_key
 
 def translate(dictionary=None, translation_rules=None):
     """


### PR DESCRIPTION
Hey Luke, great tool!  Just found a small issue with `lookup whois`.  Specifically, the non-translated output fields were dropped.  So only the various contract fields were being returned, but the dozen or so other fields were all blank.  It seems like a one-line default behavior logic issue.

Example of issue:
```
| makeresults | eval host="8.8.8.8" | lookup whois host OUTPUT asn asn_cidr contact.name
```

With 1.5.0 this populates just `contact.name`, after the patch `asn` and `asn_cird` as also populated.

Thanks!